### PR TITLE
keep tag local state when importing from json or sync from internal

### DIFF
--- a/app/Model/Event.php
+++ b/app/Model/Event.php
@@ -3463,7 +3463,7 @@ class Event extends AppModel
             foreach ($event['Tag'] as $tag) {
                 $tag_id = $this->captureTagWithCache($tag, $user, $capturedTags);
                 if ($tag_id && !in_array($tag_id, $event_tag_ids)) {
-                    $eventTags[] = array('tag_id' => $tag_id);
+                    $eventTags[] = array('tag_id' => $tag_id, 'local' => $tag['local']);
                     $event_tag_ids[] = $tag_id;
                 }
             }


### PR DESCRIPTION
#### What does it do?
Fixes MISP#7810
When importing an Event via JSON, local tags inside the json should stay local after import too, and not be attached as global ones.
Same applies for Sync-Operations from internal instances (for any other instance local tags get stripped anyway)

#### Questions

- [ ] Does it require a DB change?
- [ ] Are you using it in production?
- [ ] Does it require a change in the API (PyMISP for example)?
